### PR TITLE
LoadSettings hotfix

### DIFF
--- a/Sphere Editor/Settings/GenSettings.cs
+++ b/Sphere Editor/Settings/GenSettings.cs
@@ -102,7 +102,7 @@ namespace Sphere_Editor.Settings
                 RootPath = Path.GetDirectoryName(path);
                 while (!settings.EndOfStream)
                 {
-                    string[] lines = settings.ReadLine().Split('=');
+                    string[] lines = settings.ReadLine().Split(new char[] { '=' }, 2);
                     if (lines.Length > 1) items[lines[0]] = lines[1];
                 }
                 return true;


### PR DESCRIPTION
Fixed erroneous truncation of INI values containing '=' characters, was causing startup crashes when using bold/italic fonts
