### PR TITLE
New option to disable startpage

### DIFF
--- a/Sphere Studio/Forms/EditorSettings.Designer.cs
+++ b/Sphere Studio/Forms/EditorSettings.Designer.cs
@@ -215,7 +215,8 @@
             this.ItemCheckBox.FormattingEnabled = true;
             this.ItemCheckBox.Items.AddRange(new object[] {
             "Update Script Headers",
-            "Open Last Project"});
+            "Automatically Open Last Project",
+            "Automatically Open Start Page"});
             this.ItemCheckBox.Location = new System.Drawing.Point(6, 26);
             this.ItemCheckBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.ItemCheckBox.Name = "ItemCheckBox";

--- a/Sphere Studio/Forms/EditorSettings.cs
+++ b/Sphere Studio/Forms/EditorSettings.cs
@@ -52,6 +52,12 @@ namespace SphereStudio.Forms
             set { ItemCheckBox.SetItemChecked(1, value); }
         }
 
+        public bool UseStartPage
+        {
+            get { return ItemCheckBox.GetItemChecked(2); }
+            set { ItemCheckBox.SetItemChecked(2, value); }
+        }
+
         private bool _updatePlugins = false;
         #endregion
 
@@ -68,6 +74,7 @@ namespace SphereStudio.Forms
             GamePaths = settings.GetArray("games_path");
             AutoStart = settings.AutoOpen;
             UseScriptUpdate = settings.UseScriptUpdate;
+            UseStartPage = settings.UseStartPage;
             Style = settings.Style.ToString();
             UpdateStyle();
         }
@@ -83,6 +90,7 @@ namespace SphereStudio.Forms
             settings.SpherePath = SpherePath;
             settings.ConfigPath = ConfigPath;
             settings.UseScriptUpdate = UseScriptUpdate;
+            settings.UseStartPage = UseStartPage;
             settings.Style = Style;
             settings.StoreArray("games_path", GamePaths);
 

--- a/Sphere Studio/Forms/EditorSettings.resx
+++ b/Sphere Studio/Forms/EditorSettings.resx
@@ -123,4 +123,7 @@
   <metadata name="Tip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>146, 17</value>
   </metadata>
+  <metadata name="Tip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>146, 17</value>
+  </metadata>
 </root>

--- a/Sphere Studio/IDEForm.cs
+++ b/Sphere Studio/IDEForm.cs
@@ -144,8 +144,8 @@ namespace SphereStudio
                     Text = @"Start Page",
                     HideOnClose = true
                 };
-            _startContent.Show(DockTest, DockState.Document);
             _startContent.Controls.Add(_startPage);
+            if (EditorSettings.UseStartPage) _startContent.Show(DockTest, DockState.Document);
 
             _treeContent = new DockContent();
             _treeContent.Controls.Add(_tree);

--- a/Sphere.Core/Settings/SphereSettings.cs
+++ b/Sphere.Core/Settings/SphereSettings.cs
@@ -51,6 +51,15 @@ namespace Sphere.Core.Settings
         }
 
         /// <summary>
+        /// Gets or sets whether to open the Start Page on startup
+        /// </summary>
+        public bool UseStartPage
+        {
+            get { return GetBool("use_start_page", true); }
+            set { SetItem("use_start_page", value); }
+        }
+
+        /// <summary>
         /// Gets or sets the start page's view.
         /// </summary>
         public View StartView


### PR DESCRIPTION
The start page can sometimes be redundant if you have the editor set to open the last project (like I do), so I added an option to enable or disable it (default is on).
