### PR TITLE
Make Repeat Map setting work

### DIFF
--- a/MapEditPlugin/Forms/MapPropertiesForm.cs
+++ b/MapEditPlugin/Forms/MapPropertiesForm.cs
@@ -22,6 +22,7 @@ namespace SphereStudio.Plugins.Forms
             ScriptPanel.Controls.Add(ScriptBox);
             TilesetTextbox.Text = this.scripts[0];
             //BgMusicTextbox.Text = this.scripts[1];
+            RepeatMapCheckBox.Checked = map.WrapAround;
             ScriptBox.Text = this.scripts[3];
             TileWidthBox.Text = "" + map.Tileset.TileWidth;
             TileHeightBox.Text = "" + map.Tileset.TileHeight;
@@ -88,6 +89,8 @@ namespace SphereStudio.Plugins.Forms
 
         private void OkayButton_Click(object sender, EventArgs e)
         {
+            Map.WrapAround = RepeatMapCheckBox.Checked;
+            
             short tw = 0, th = 0;
             short lw = 0, lh = 0;
             if (TileWidthBox.Text != String.Empty) tw = short.Parse(TileWidthBox.Text);

--- a/Sphere.Core/Map.cs
+++ b/Sphere.Core/Map.cs
@@ -14,6 +14,11 @@ namespace Sphere.Core
         private short _version = 1;
 
         /// <summary>
+        /// Gets or sets whether the map wraps around at the edges (i.e. is a toric map)
+        /// </summary>
+        public bool WrapAround { get; set; }
+        
+        /// <summary>
         /// Gets or sets the starting x position.
         /// </summary>
         public short StartX { get; set; }
@@ -139,7 +144,8 @@ namespace Sphere.Core
                 reader.ReadByte();
                 int numStrings = reader.ReadInt16();
                 int numZones = reader.ReadInt16();
-                reader.ReadBytes(235);
+                WrapAround = reader.ReadBoolean();
+                reader.ReadBytes(234);
 
                 // read scripts:
                 while (numStrings-- > 0)
@@ -204,7 +210,8 @@ namespace Sphere.Core
                 writer.Write(byte.MinValue);
                 writer.Write((short)Scripts.Count);
                 writer.Write((short)Zones.Count);
-                writer.Write(new byte[235]);
+                writer.Write(WrapAround);
+                writer.Write(new byte[234]);
 
                 // write scripts:
                 foreach (string s in Scripts)


### PR DESCRIPTION
Apparently the RMP spec was written before repeating maps were implemented.  Nonetheless, after a quick look at the Sphere 1.5 source it works now.