### PR TITLE
Per-user config support

### DIFF
--- a/SPKPackerPlugin/MakePackageForm.cs
+++ b/SPKPackerPlugin/MakePackageForm.cs
@@ -28,7 +28,8 @@ namespace Sphere.Plugins
     public partial class MakePackageForm : Form
     {
         private readonly string[] extensions = {
-            ".sgm", ".rmp", ".rss", ".rts", ".rfn", ".rws", ".js",
+            ".sgm", ".rmp", ".rss", ".rts", ".rfn", ".rws",
+            ".js", ".coffee", ".glsl",
             ".png", ".jpg", ".bmp", ".pcx",
             ".mp3", ".ogg", ".mid", ".wav", ".flac", ".it", ".s3m", ".mod",
         };

--- a/SPKPackerPlugin/MakePackageForm.cs
+++ b/SPKPackerPlugin/MakePackageForm.cs
@@ -107,6 +107,7 @@ namespace Sphere.Plugins
                 dialog.InitialDirectory = packageDir;
                 dialog.OverwritePrompt = true;
                 dialog.AutoUpgradeEnabled = true;
+                dialog.FileName = Path.GetFileName(projectPath);
                 if (dialog.ShowDialog(this) == DialogResult.OK)
                 {
                     spkWriter = new BinaryWriter(File.Create(dialog.FileName), Encoding.GetEncoding(1252));

--- a/SPKPackerPlugin/MakePackageForm.cs
+++ b/SPKPackerPlugin/MakePackageForm.cs
@@ -95,6 +95,8 @@ namespace Sphere.Plugins
         {
             const int bufferSize = 1048576;
 
+            var packageDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), @"Sphere Studio\Packages");
+            Directory.CreateDirectory(packageDir);
             BinaryWriter spkWriter = null;
             using (var dialog = new SaveFileDialog())
             {
@@ -102,7 +104,7 @@ namespace Sphere.Plugins
                 dialog.Filter = "Sphere Package (.spk)|*.spk";
                 dialog.AddExtension = true;
                 dialog.DefaultExt = "spk";
-                dialog.InitialDirectory = projectPath;
+                dialog.InitialDirectory = packageDir;
                 dialog.OverwritePrompt = true;
                 dialog.AutoUpgradeEnabled = true;
                 if (dialog.ShowDialog(this) == DialogResult.OK)

--- a/ScriptEditPlugin/ScriptEditPlugin.cs
+++ b/ScriptEditPlugin/ScriptEditPlugin.cs
@@ -18,7 +18,7 @@ namespace SphereStudio.Plugins
         public Icon Icon { get; private set; }
 
         private readonly List<string> _extensionList = new List<string>(new[] { ".js", "*" });
-        private const string _openFileFilters = "*.js;*.txt;*.log;*.md;*.sgm;*.ini;*.sav";
+        private const string _openFileFilters = "*.js;*.coffee;*.txt;*.log;*.md;*.sgm;*.ini;*.sav";
 
         readonly ToolStripMenuItem _rootMenu, _indentMenu, _newScriptItem;
         readonly ToolStripMenuItem _autoCompleteItem, _codeFoldItem;

--- a/ScriptEditPlugin/ScriptEditor.cs
+++ b/ScriptEditPlugin/ScriptEditor.cs
@@ -173,7 +173,8 @@ namespace SphereStudio.Plugins
         {
             using (SaveFileDialog diag = new SaveFileDialog())
             {
-                diag.Filter = @"Sphere Script Files (.js)|*.js";
+                diag.Filter = @"Sphere Script Files (.js, .coffee)|*.js;*.coffee";
+                diag.DefaultExt = "js";
 
                 if (PluginManager.IDE.CurrentGame != null)
                     diag.InitialDirectory = PluginManager.IDE.CurrentGame.RootPath + "\\scripts";

--- a/ScriptEditPlugin/ScriptEditor.cs
+++ b/ScriptEditPlugin/ScriptEditor.cs
@@ -173,7 +173,7 @@ namespace SphereStudio.Plugins
         {
             using (SaveFileDialog diag = new SaveFileDialog())
             {
-                diag.Filter = @"Sphere Script Files (.js, .coffee)|*.js;*.coffee";
+                diag.Filter = @"JavaScript (.js)|*.js|CoffeeScript (.coffee)|*.coffee";
                 diag.DefaultExt = "js";
 
                 if (PluginManager.IDE.CurrentGame != null)

--- a/Sphere Studio/Components/StartPage.cs
+++ b/Sphere Studio/Components/StartPage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
@@ -99,7 +100,9 @@ namespace SphereStudio.Components
             _listIcons.Images.Add(holdOnToMe);
 
             // Search through a list of supplied directories.
-            string[] paths = Global.CurrentEditor.GetArray("games_path");
+            string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
+            var paths = new List<string>(Global.CurrentEditor.GetArray("games_path"));
+            paths.Insert(0, Path.Combine(sphereDir, @"Projects"));
             foreach (string s in paths)
             {
                 if (string.IsNullOrEmpty(s)) continue;

--- a/Sphere Studio/Forms/EditorSettings.Designer.cs
+++ b/Sphere Studio/Forms/EditorSettings.Designer.cs
@@ -330,7 +330,7 @@
             this.editorLabel4.Name = "editorLabel4";
             this.editorLabel4.Size = new System.Drawing.Size(400, 23);
             this.editorLabel4.TabIndex = 8;
-            this.editorLabel4.Text = "Game Paths";
+            this.editorLabel4.Text = "Additional Project Paths";
             this.editorLabel4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // Sphere64PathLabel

--- a/Sphere Studio/Forms/EditorSettings.cs
+++ b/Sphere Studio/Forms/EditorSettings.cs
@@ -191,7 +191,8 @@ namespace SphereStudio.Forms
         {
             PresetListBox.Items.Clear();
 
-            string path = Path.Combine(Application.StartupPath, "Presets");
+            string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
+            string path = Path.Combine(sphereDir, @"Presets");
             if (!Directory.Exists(path)) return;
 
             string[] files = Directory.GetFiles(path, "*.preset");
@@ -222,7 +223,8 @@ namespace SphereStudio.Forms
 
         private void RemovePresetButton_Click(object sender, EventArgs e)
         {
-            string path = Path.Combine(Application.StartupPath, "Presets", (string)PresetListBox.SelectedItem + ".preset");
+            string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
+            string path = Path.Combine(sphereDir, @"Presets", (string)PresetListBox.SelectedItem + ".preset");
             if (File.Exists(path)) File.Delete(path);
             PresetListBox.Items.RemoveAt(PresetListBox.SelectedIndex);
             RemovePresetButton.Enabled = PresetListBox.Items.Count > 0 && PresetListBox.SelectedIndex > 0;
@@ -234,9 +236,10 @@ namespace SphereStudio.Forms
             {
                 if (form.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                 {
+                    string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
+                    Directory.CreateDirectory(Path.Combine(sphereDir, @"Presets"));
                     string presetName = form.Input;
-                    Directory.CreateDirectory(Path.Combine(Application.StartupPath, "Presets"));
-                    string filePath = Path.Combine(Application.StartupPath, "Presets", presetName + ".preset");
+                    string filePath = Path.Combine(sphereDir, @"Presets", presetName + ".preset");
                     bool continueSave = true;
                     if (File.Exists(filePath))
                     {
@@ -262,7 +265,8 @@ namespace SphereStudio.Forms
         private void UsePresetButton_Click(object sender, EventArgs e)
         {
             SphereSettings settings = new SphereSettings();
-            string path = Path.Combine(Application.StartupPath, "Presets", (string)PresetListBox.SelectedItem + ".preset");
+            string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
+            string path = Path.Combine(sphereDir, @"Presets", (string)PresetListBox.SelectedItem + ".preset");
             settings.LoadSettings(path);
             settings.LastPreset = (string)PresetListBox.SelectedItem;
             SetValues(settings);

--- a/Sphere Studio/Forms/EditorSettings.cs
+++ b/Sphere Studio/Forms/EditorSettings.cs
@@ -253,7 +253,7 @@ namespace SphereStudio.Forms
                         GenSettings old = Global.CurrentEditor.Clone();
                         Global.CurrentEditor.SetSettings(GetSettings());
                         Global.CurrentEditor.LastPreset = presetName;
-                        Global.CurrentEditor.SaveSettings(filePath);
+                        Global.CurrentEditor.SaveSettings(filePath, true);
                         Global.CurrentEditor.SetSettings(old);
                         UpdatePresetBox();
                     }

--- a/Sphere Studio/Forms/GameSettings.cs
+++ b/Sphere Studio/Forms/GameSettings.cs
@@ -10,21 +10,25 @@ namespace SphereStudio.Forms
 {
     internal partial class GameSettings : Form, IStyleable
     {
+        private ProjectSettings _project;
+        
         public GameSettings(ProjectSettings someProject)
         {
             InitializeComponent();
-            PathTextBox.Text = someProject.RootPath;
-            NameTextBox.Text = someProject.Name;
-            AuthorTextBox.Text = someProject.Author;
-            DescTextBox.Text = someProject.Description;
-            WidthTextBox.Text = someProject.Width;
-            HeightTextBox.Text = someProject.Height;
-            ScriptComboBox.Text = someProject.Script;
             UpdateStyle();
+
+            _project = someProject;
         }
 
         private void GameSettings_Load(object sender, EventArgs e)
         {
+            PathTextBox.Text = _project.RootPath;
+            NameTextBox.Text = _project.Name;
+            AuthorTextBox.Text = _project.Author;
+            DescTextBox.Text = _project.Description;
+            WidthTextBox.Text = _project.Width;
+            HeightTextBox.Text = _project.Height;
+            
             // I'll need to populate the script combo box.
             DirectoryInfo dir = new DirectoryInfo(PathTextBox.Text + "\\scripts");
 
@@ -36,6 +40,7 @@ namespace SphereStudio.Forms
             {
                 ScriptComboBox.Items.Add(filename);
             }
+            ScriptComboBox.Text = _project.Script;
         }
 
         public ProjectSettings GetSettings()

--- a/Sphere Studio/Forms/GameSettings.cs
+++ b/Sphere Studio/Forms/GameSettings.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Windows.Forms;
 using Sphere.Core.Settings;
 using Sphere.Core.Editor;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SphereStudio.Forms
 {
@@ -25,10 +27,14 @@ namespace SphereStudio.Forms
         {
             // I'll need to populate the script combo box.
             DirectoryInfo dir = new DirectoryInfo(PathTextBox.Text + "\\scripts");
-            FileInfo[] scriptList = dir.GetFiles("*.js");
-            for (int i = 0; i < scriptList.Length; ++i)
+
+            var scriptList = from FileInfo file in dir.EnumerateFiles("*")
+                             where file.Extension == ".js" || file.Extension == ".coffee"
+                             orderby file.Name ascending
+                             select file.Name;
+            foreach (string filename in scriptList)
             {
-                ScriptComboBox.Items.Add(scriptList[i].Name);
+                ScriptComboBox.Items.Add(filename);
             }
         }
 

--- a/Sphere Studio/Forms/GameSettings.designer.cs
+++ b/Sphere Studio/Forms/GameSettings.designer.cs
@@ -140,6 +140,7 @@
             // 
             // ScriptComboBox
             // 
+            this.ScriptComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ScriptComboBox.FormattingEnabled = true;
             this.ScriptComboBox.Location = new System.Drawing.Point(112, 347);
             this.ScriptComboBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
@@ -246,6 +247,7 @@
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "GameSettings";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Game Settings";
             this.Load += new System.EventHandler(this.GameSettings_Load);
             ((System.ComponentModel.ISupportInitialize)(this.NewProjectPic)).EndInit();

--- a/Sphere Studio/IDEForm.Designer.cs
+++ b/Sphere Studio/IDEForm.Designer.cs
@@ -369,11 +369,13 @@
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.toolStripSeparator2.Size = new System.Drawing.Size(6, 30);
             // 
             // toolStripLabel1
             // 
             this.toolStripLabel1.Name = "toolStripLabel1";
+            this.toolStripLabel1.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.toolStripLabel1.Size = new System.Drawing.Size(81, 27);
             this.toolStripLabel1.Text = "Configuration";
             // 
@@ -382,6 +384,7 @@
             this.ConfigSelectTool.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ConfigSelectTool.FlatStyle = System.Windows.Forms.FlatStyle.Standard;
             this.ConfigSelectTool.Name = "ConfigSelectTool";
+            this.ConfigSelectTool.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.ConfigSelectTool.Size = new System.Drawing.Size(128, 30);
             this.ConfigSelectTool.SelectedIndexChanged += new System.EventHandler(this.ConfigSelectTool_SelectedIndexChanged);
             // 

--- a/Sphere Studio/IDEForm.cs
+++ b/Sphere Studio/IDEForm.cs
@@ -79,7 +79,8 @@ namespace SphereStudio
             ConfigSelectTool.Items.Add("[Select a preset]");
             ConfigSelectTool.SelectedIndex = 0;
 
-            string path = Path.Combine(Application.StartupPath, "Presets");
+            string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
+            string path = Path.Combine(sphereDir, @"Presets");
             if (Directory.Exists(path))
             {
                 string[] presetFiles = Directory.GetFiles(path, "*.preset");
@@ -516,11 +517,10 @@ namespace SphereStudio
         public void CallNewProject(object sender, EventArgs e)
         {
             string[] paths = Global.CurrentEditor.GetArray("games_path");
-            string rootpath = "";
-            if (paths.Length > 0) rootpath = paths[0];
-            else
-                rootpath = Application.StartupPath;
-            NewProjectForm myProject = new NewProjectForm { RootFolder = rootpath };
+            string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
+            string rootPath = Path.Combine(sphereDir, "Projects");
+            Directory.CreateDirectory(rootPath);
+            NewProjectForm myProject = new NewProjectForm { RootFolder = rootPath };
 
             if (myProject.ShowDialog() == DialogResult.OK)
             {
@@ -931,7 +931,8 @@ namespace SphereStudio
             if (ConfigSelectTool.SelectedIndex <= 0)
                 return;
 
-            string path = Path.Combine(Application.StartupPath, "presets", (string)ConfigSelectTool.SelectedItem + ".preset");
+            string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
+            string path = Path.Combine(sphereDir, @"Presets", (string)ConfigSelectTool.SelectedItem + ".preset");
             Global.CurrentEditor.LoadSettings(path);
             Global.CurrentEditor.LastPreset = ConfigSelectTool.Text;
             Global.CurrentEditor.LastProjectPath = Global.CurrentProject != null ? Global.CurrentProject.RootPath : "";

--- a/Sphere Studio/IDEForm.cs
+++ b/Sphere Studio/IDEForm.cs
@@ -26,6 +26,7 @@ namespace SphereStudio
         private readonly Dictionary<string, string> _openFileTypes = new Dictionary<string, string>();
         private readonly Dictionary<EditorType, IEditorPlugin> _editors = new Dictionary<EditorType, IEditorPlugin>();
         private string _default_active;
+        private bool _loadingPresets = false;
 
         public event EventHandler LoadProject;
         public event EventHandler TestGame;
@@ -75,8 +76,11 @@ namespace SphereStudio
 
         private void UpdatePresetList()
         {
+            bool wasLoadingPresets = _loadingPresets;
+            _loadingPresets = true;
+            
             ConfigSelectTool.Items.Clear();
-            ConfigSelectTool.Items.Add("[Select a preset]");
+            ConfigSelectTool.Items.Add("[Select a Preset]");
             ConfigSelectTool.SelectedIndex = 0;
 
             string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
@@ -90,6 +94,9 @@ namespace SphereStudio
                 }
                 ConfigSelectTool.SelectedItem = Global.CurrentEditor.LastPreset;
             }
+            ConfigSelectTool.Items.Add("Settings Manager...");
+
+            _loadingPresets = wasLoadingPresets;
         }
 
         void IDEForm_TryEditFile(object sender, EditFileEventArgs e)
@@ -928,8 +935,16 @@ namespace SphereStudio
 
         private void ConfigSelectTool_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (ConfigSelectTool.SelectedIndex <= 0)
+            if (_loadingPresets) return;
+            
+            // open settings if Settings Manager selected, ignore cue banner item
+            if (ConfigSelectTool.SelectedIndex == 0 || ConfigSelectTool.SelectedIndex == ConfigSelectTool.Items.Count - 1)
+            {
+                if (ConfigSelectTool.SelectedIndex != 0)
+                    OpenEditorSettings();
+                UpdatePresetList();
                 return;
+            }
 
             string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
             string path = Path.Combine(sphereDir, @"Presets", (string)ConfigSelectTool.SelectedItem + ".preset");
@@ -948,6 +963,8 @@ namespace SphereStudio
 
             Global.CurrentEditor.SaveSettings();
             ApplyRefresh(true);
+
+            _loadingPresets = false;
         }
     }
 }

--- a/Sphere Studio/Program.cs
+++ b/Sphere Studio/Program.cs
@@ -20,7 +20,11 @@ namespace SphereStudio
             // check for and open files dragged onto it.
             foreach (string s in args)
             {
-                if (File.Exists(s)) form.OpenDocument(s);
+                if (!File.Exists(s)) continue;
+                if (Path.GetExtension(s) == ".sgm")
+                    form.OpenProject(s);
+                else
+                    form.OpenDocument(s);
             }
 
             if (args.Length > 0 && File.Exists(args[args.Length - 1]))

--- a/Sphere.Core/Settings/GameProject.cs
+++ b/Sphere.Core/Settings/GameProject.cs
@@ -67,7 +67,7 @@ namespace Sphere.Core.Settings
         /// </summary>
         public void SaveSettings()
         {
-            SaveSettings(string.Format("{0}\\game.sgm", RootPath));
+            SaveSettings(string.Format("{0}\\game.sgm", RootPath), false);
         }
 
         /// <summary>

--- a/Sphere.Core/Settings/GenSettings.cs
+++ b/Sphere.Core/Settings/GenSettings.cs
@@ -114,6 +114,7 @@ namespace Sphere.Core.Settings
         {
             using (var settings = new StreamWriter(path))
             {
+                settings.WriteLine("[Sphere Studio]");
                 for (int i = 0; i < _items.Count; ++i)
                 {
                     string key = _items.Keys[i];
@@ -148,7 +149,8 @@ namespace Sphere.Core.Settings
                 while (!settings.EndOfStream)
                 {
                     var readLine = settings.ReadLine();
-                    if (readLine == null) continue;
+                    if (readLine == null || readLine == "[Sphere Studio]")
+                        continue;
                     var lines = readLine.Split(new[] { '=' }, 2);
                     if (lines.Length > 1) _items[lines[0]] = lines[1];
                 }

--- a/Sphere.Core/Settings/GenSettings.cs
+++ b/Sphere.Core/Settings/GenSettings.cs
@@ -110,11 +110,12 @@ namespace Sphere.Core.Settings
         /// Saves these settings to file.
         /// </summary>
         /// <param name="path">Filepath to store the settings.</param>
-        public virtual void SaveSettings(string path)
+        public virtual void SaveSettings(string path, bool wantHeader)
         {
             using (var settings = new StreamWriter(path))
             {
-                settings.WriteLine("[Sphere Studio]");
+                if (wantHeader)
+                    settings.WriteLine("[Sphere Studio]");
                 for (int i = 0; i < _items.Count; ++i)
                 {
                     string key = _items.Keys[i];

--- a/Sphere.Core/Settings/SphereSettings.cs
+++ b/Sphere.Core/Settings/SphereSettings.cs
@@ -136,7 +136,7 @@ namespace Sphere.Core.Settings
         {
             string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
             Directory.CreateDirectory(Path.Combine(sphereDir, "Settings"));
-            SaveSettings(Path.Combine(sphereDir, @"Settings\editor.ini"));
+            SaveSettings(Path.Combine(sphereDir, @"Settings\editor.ini"), true);
         }
 
         /// <summary>

--- a/Sphere.Core/Settings/SphereSettings.cs
+++ b/Sphere.Core/Settings/SphereSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Windows.Forms;
 
 // This Contains the Settings Dialogue Info
@@ -133,7 +134,9 @@ namespace Sphere.Core.Settings
         /// </summary>
         public void SaveSettings()
         {
-            SaveSettings(Application.StartupPath + "\\editor.ini");
+            string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
+            Directory.CreateDirectory(Path.Combine(sphereDir, "Settings"));
+            SaveSettings(Path.Combine(sphereDir, @"Settings\editor.ini"));
         }
 
         /// <summary>
@@ -141,7 +144,8 @@ namespace Sphere.Core.Settings
         /// </summary>
         public bool LoadSettings()
         {
-            return LoadSettings(Application.StartupPath + "\\editor.ini");
+            string sphereDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Sphere Studio");
+            return LoadSettings(Path.Combine(sphereDir, @"Settings\editor.ini"));
         }
 
         /// <summary>


### PR DESCRIPTION
This allows Sphere Studio to run from read-only directories such as Program Files without crashing.  All user config (projects, settings, presets...) is stored in My Documents\Sphere Studio, which also makes it easier to back those things up.  As a bonus, plugins can be loaded from the user directory as well, making it easier to add plugins.